### PR TITLE
Python version bump

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.16
 
 ARG PYTHON_VERSION=3.8.5
 ARG ASSET_VERSION=local_build

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,8 @@ LABEL name="sensu/sensu-python-runtime-alpine"
 
 RUN apk --no-cache add build-base gmp-dev zlib-dev bzip2-dev sqlite-dev gdbm-dev db-dev readline-dev libffi-dev coreutils yaml-dev linux-headers autoconf \
   openssh-client openssl-dev libc6-compat \ 
-  wget git sudo bash bash-doc bash-completion
+  wget git sudo bash bash-doc bash-completion \
+	xz-dev
 
 COPY scripts/pyenv-install pyenv-install
 COPY scripts/binary_shim   binary_shim 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -6,7 +6,7 @@ ARG PYTHON_VERSION=3.8.5
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
 
-RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl bzip2-devel zlib-devel sqlite-devel openssl-devel readline-devel
+RUN yum update -y && yum groupinstall -y "Development Tools" && yum install -y curl bzip2-devel zlib-devel sqlite-devel openssl-devel readline-devel libffi-devel xz-devel
 
 COPY scripts/pyenv-install pyenv-install
 RUN ./pyenv-install

--- a/Dockerfile.debian10
+++ b/Dockerfile.debian10
@@ -1,13 +1,13 @@
-FROM debian:8
+FROM debian:10
 
-LABEL name="sensu/sensu-python-runtime-debian8"
+LABEL name="sensu/sensu-python-runtime-debian10"
 
 ARG PYTHON_VERSION=3.8.5
 ARG ASSET_VERSION=local_build
 ARG GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
 
 
-RUN apt-get update && apt-get install -y build-essential zlib1g-dev libsqlite0-dev libbz2-dev libreadline-dev libssl-dev curl git
+RUN apt-get update && apt-get install -y build-essential zlib1g-dev libsqlite0-dev libbz2-dev libreadline-dev libssl-dev curl git libsqlite3-dev liblzma-dev libffi-dev
 COPY scripts/pyenv-install pyenv-install
 RUN ./pyenv-install
 
@@ -15,7 +15,7 @@ RUN LIBS=$(find /build/pyenv -type f -executable -exec ldd {} 2>/dev/null \;|  g
   for f in $LIBS; do if [ -e $f ]; then echo "Copying Library: $f" && cp $f /build/lib/; fi; done
 
 RUN mkdir /assets/ && \
-  export SENSU_ASSET="/assets/sensu-python-runtime_${ASSET_VERSION}_python-${PYTHON_VERSION}_debian8_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
+  export SENSU_ASSET="/assets/sensu-python-runtime_${ASSET_VERSION}_python-${PYTHON_VERSION}_debian10_$(uname -s | tr '[:upper:]' '[:lower:]')_amd64.tar.gz" && \
   tar -czf $SENSU_ASSET -C /build/ .
 
 ENV PATH=$PATH:/build/bin

--- a/build_and_test_platform.sh
+++ b/build_and_test_platform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ignore_errors=0
-python_version=3.6.11
+python_version=3.8.14
 asset_version=${TRAVIS_TAG:-local-build}
 asset_filename=sensu-python-runtime_${asset_version}_python-${python_version}_${platform}_linux_amd64.tar.gz
 asset_image=sensu-python-runtime-${python_version}-${platform}:${asset_version}

--- a/build_and_test_platform.sh
+++ b/build_and_test_platform.sh
@@ -38,7 +38,7 @@ fi
 test_arr=($test_platforms)
 for test_platform in "${test_arr[@]}"; do
   echo "Test: ${test_platform}"
-  docker run --rm --name python_runtime_platform_test -e platform -e test_platform=${test_platform} -e asset_filename=${asset_filename} -v "$PWD/tests/:/tests" -v "$PWD/dist:/dist" ${test_platform} /tests/test.sh
+  docker run --rm --name python_runtime_platform_test -e "PYTHON_VERSION=$python_version" -e platform -e test_platform=${test_platform} -e asset_filename=${asset_filename} -v "$PWD/tests/:/tests" -v "$PWD/dist:/dist" ${test_platform} /tests/test.sh
   retval=$?
   if [ $retval -ne 0 ]; then
     echo "!!! Error testing ${asset_filename} on ${test_platform}"

--- a/build_and_test_platform.sh
+++ b/build_and_test_platform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ignore_errors=0
-python_version=3.11.1
+python_version=3.9.16
 asset_version=${TRAVIS_TAG:-local-build}
 asset_filename=sensu-python-runtime_${asset_version}_python-${python_version}_${platform}_linux_amd64.tar.gz
 asset_image=sensu-python-runtime-${python_version}-${platform}:${asset_version}

--- a/build_platforms.sh
+++ b/build_platforms.sh
@@ -19,7 +19,7 @@ if [[ retval -ne 0 ]]; then
 fi
 
 # CentOS7 platform
-platform="centos7" test_platforms=" almalinux:8 centos:7 almalinux:9" ./build_and_test_platform.sh
+platform="centos7" test_platforms="centos:7 almalinux:8 almalinux:9" ./build_and_test_platform.sh
 retval=$?
 if [[ retval -ne 0 ]]; then
   exit $retval

--- a/build_platforms.sh
+++ b/build_platforms.sh
@@ -5,28 +5,21 @@ mkdir -p assets
 mkdir -p scripts
 
 # Alpine platform
-platform="alpine" test_platforms="alpine:latest alpine:3 alpine:3.8" ./build_and_test_platform.sh
+platform="alpine" test_platforms="alpine:latest alpine:3 alpine:3.16" ./build_and_test_platform.sh
 retval=$?
 if [[ retval -ne 0 ]]; then
   exit $retval
 fi
 
 # Debian8 platform
-platform="debian8" test_platforms="debian:8 debian:9 debian:10 ubuntu:20.04 ubuntu:16.04 ubuntu:18.04 centos:7 centos:8" ./build_and_test_platform.sh
+platform="debian10" test_platforms="debian:10 debian:11 ubuntu:20.04 ubuntu:18.04" ./build_and_test_platform.sh
 retval=$?
 if [[ retval -ne 0 ]]; then
   exit $retval
 fi
 
 # CentOS7 platform
-platform="centos7" test_platforms="centos:8 centos:7 debian:8 debian:9 debian:10 ubuntu:16.04 ubuntu:18.04" ./build_and_test_platform.sh
-retval=$?
-if [[ retval -ne 0 ]]; then
-  exit $retval
-fi
-
-# CentOS6 platform
-platform="centos6" test_platforms="centos:6 centos:8 centos:7 debian:8 debian:9 debian:10 ubuntu:16.04 ubuntu:18.04" ./build_and_test_platform.sh
+platform="centos7" test_platforms=" almalinux:8 centos:7 almalinux:9" ./build_and_test_platform.sh
 retval=$?
 if [[ retval -ne 0 ]]; then
   exit $retval

--- a/build_platforms.sh
+++ b/build_platforms.sh
@@ -12,7 +12,7 @@ if [[ retval -ne 0 ]]; then
 fi
 
 # Debian8 platform
-platform="debian10" test_platforms="debian:10 debian:11 ubuntu:20.04 ubuntu:18.04" ./build_and_test_platform.sh
+platform="debian10" test_platforms="debian:10 debian:11 ubuntu:20.04" ./build_and_test_platform.sh
 retval=$?
 if [[ retval -ne 0 ]]; then
   exit $retval

--- a/scripts/pyenv-install
+++ b/scripts/pyenv-install
@@ -3,8 +3,7 @@ set -e
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)" 
-pyenv install ${PYTHON_VERSION}
+~/.pyenv/bin/pyenv install ${PYTHON_VERSION}
 mkdir -p build/bin
 mkdir -p build/lib
 cp -r $PYENV_ROOT build/pyenv

--- a/scripts/pyenv-install
+++ b/scripts/pyenv-install
@@ -1,6 +1,7 @@
 #!/bin/sh
-git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-export PYENV_ROOT="$HOME/.pyenv" && \
+set -e
+git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)" 
 pyenv install ${PYTHON_VERSION}
@@ -10,4 +11,3 @@ cp -r $PYENV_ROOT build/pyenv
 cd build/bin
 ln -s ../pyenv/versions/${PYTHON_VERSION}/bin/python python
 ln -s ../pyenv/versions/${PYTHON_VERSION}/bin/pip pip
-

--- a/tests/lzma_test.py
+++ b/tests/lzma_test.py
@@ -1,0 +1,2 @@
+import lzma
+print(lzma.compress(b"Hello World"))

--- a/tests/sqlite_test.py
+++ b/tests/sqlite_test.py
@@ -1,0 +1,4 @@
+import sqlite3
+con = sqlite3.connect(":memory:")
+cur = con.cursor()
+cur.execute("CREATE TABLE movie(title, year, score)")

--- a/tests/ssl_test.py
+++ b/tests/ssl_test.py
@@ -1,0 +1,14 @@
+import socket
+import ssl
+
+context = ssl.create_default_context()
+context.check_hostname = False # Debian and Ubuntu containers ship with no certs
+context.verify_mode = ssl.CERT_NONE
+
+hostname = 'www.google.com'
+
+print(ssl.get_default_verify_paths())
+
+with socket.create_connection((hostname, 443)) as sock:
+    with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+		        print(ssock.version())

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,6 +11,6 @@ mkdir -p /build
 cd /build
 tar xzf /dist/$asset_filename
 #LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/test_ssl_url.py
-LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" [ "$(/build/bin/python --version)" = "Python 3.6.11" ]
+[ "$(LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python --version)" = "Python ${PYTHON_VERSION}" ]
 LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/uuid_test.py
 LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/module_search_path.py

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 echo "Test Script:"
 echo "  Asset Platform:  ${platform}"
 echo "  Target Platform: ${test_platform}"
@@ -10,7 +11,9 @@ fi
 mkdir -p /build
 cd /build
 tar xzf /dist/$asset_filename
-#LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/test_ssl_url.py
 [ "$(LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python --version)" = "Python ${PYTHON_VERSION}" ]
 LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/uuid_test.py
+LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/ssl_test.py
+LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/lzma_test.py
+LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/sqlite_test.py
 LD_LIBRARY_PATH="/build/lib:$LD_LIBRARY_PATH" /build/bin/python /tests/module_search_path.py


### PR DESCRIPTION
- New libraries are required
- Dropped EOL'd distributions- CentOS 6, Debian 8, Alpine 3.8
- Dropped Ubuntu 18.04, since Debian 10 (the oldest supported docker image for Debian) doesn't build binaries that work cleanly there.